### PR TITLE
Add log4j2-core dependencies

### DIFF
--- a/javaapps/build.gradle
+++ b/javaapps/build.gradle
@@ -12,7 +12,12 @@ repositories {
 
 dependencies {
 	compile 'org.apache.geode:geode-core:1.11.0'
-	testCompile "junit:junit:4.12" 
+	compile "org.apache.logging.log4j:log4j-api:2.12.0"
+	compile "org.apache.logging.log4j:log4j-core:2.12.0"
+	compile "org.slf4j:slf4j-log4j12:1.7.25"
+	compile "org.slf4j:slf4j-api:1.7.25"
+
+	testCompile "junit:junit:4.12"
 }
 
 compileJava {

--- a/javaapps/src/main/java/geode/handson/cui/ChatMessageListener.java
+++ b/javaapps/src/main/java/geode/handson/cui/ChatMessageListener.java
@@ -2,6 +2,7 @@ package geode.handson.cui;
 
 import java.util.Properties;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Declarable;
 import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.util.CacheListenerAdapter;
@@ -15,10 +16,11 @@ public class ChatMessageListener extends CacheListenerAdapter<String, String> im
 	/**
 	 * このイベントハンドラクラスを初期化します。<br>
 	 * このクラスでは特に何も行いません。<br>
+	 * @param cache Cacheオブジェクト
 	 * @param props Propertiesオブジェクト
 	 */
 	@Override
-	public void init(Properties props) {
+	public void initialize(Cache cache, Properties props) {
 	}
 
 	/**

--- a/javaapps/src/main/resources/log4j2.xml
+++ b/javaapps/src/main/resources/log4j2.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+</Configuration>


### PR DESCRIPTION
- log4j2エラー除去のため不足していた依存ライブラリをbuild.gradleへ追加した
- Declarableインターフェースのinitメソッドがdeprecatedとなったためinitializeメソッドへ変更した